### PR TITLE
Bump set-value to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   },
   "resolutions": {
     "@types/react": "^17"
+  },
+  "dependencies": {
+    "set-value": "^2.0.1"
   }
 }


### PR DESCRIPTION
To fix `set-value` vulnerability.
![image](https://user-images.githubusercontent.com/538584/134106543-d1ef681a-1c2b-47c0-a1d7-c82c37446b91.png)
